### PR TITLE
Add documentation to carrow.h

### DIFF
--- a/carrow.h
+++ b/carrow.h
@@ -108,62 +108,88 @@
 #define CWAKEUP  EPOLLWAKEUP   // 536870912
 
 
+/* A struct representing a coroutine state.
+   It contains the file descriptor, the event mask,
+   and the line number where the coroutine was last suspended. */
 struct carrow_generic_coro {
     void *run;
     int line;
     int fd;
-    int events;
+    int events; // event mask
 };
 
-
+/* A function pointer type representing a coroutine handler function. */
 typedef void (*carrow_generic_corofunc) (void *coro, void *state);
 
 
+/* A function that initializes the event loop with the given maximum number
+   of file descriptors. */
 int
 carrow_init(unsigned int openmax);
 
 
+/* A function that frees the memory allocated for the _evbags array. */
 void
 carrow_deinit();
 
-
+/* A function that registers a coroutine with the event loop for a given file
+   descriptor and event mask. It sets the evbag for the given file descriptor
+   with the provided coroutine state and handler function, and adds the file
+   descriptor to the epoll instance. */
 int
 carrow_evloop_register(void *coro, void *state, int fd, int events,
         carrow_generic_corofunc handler);
 
-
+/* A function that modifies the coroutine state and handler function for a
+   given file descriptor in the event loop. */
 int
 carrow_evloop_modify(void *c, void *state, int fd, int events,
         carrow_generic_corofunc handler);
 
 
+/* A function that modifies the coroutine state and handler function for a
+   given file descriptor in the event loop if it exists, or registers a new
+   coroutine with the provided state and handler function if it does not. */
 int
 carrow_evloop_modify_or_register(void *coro, void *state, int fd, int events,
         carrow_generic_corofunc handler);
 
-
+/* A function that unregisters a coroutine for a given file descriptor from
+   the event loop and deletes its evbag. */
 int
 carrow_evloop_unregister(int fd);
 
-
+/* A function that runs the event loop until the _evbagscount is zero or
+   the status is set to a value less than or equal to EXIT_FAILURE.
+   It waits for events on the epoll instance and triggers thecorresponding
+   coroutines when events occur. */
 int
 carrow_evloop(volatile int *status);
 
-
+/* A function that set the coroutine state and coroutine handler for the 
+   given file descriptor. */
 int
 carrow_evbag_unpack(int fd, struct carrow_generic_coro *coro, void **state,
         carrow_generic_corofunc *handler);
 
 
+/* A function that installs a signal handler for SIGINT that sets the
+   _carrow_status variable to EXIT_SUCCESS.*/
 int
 carrow_handleinterrupts();
 
 
+/*  A function that creates a timer file descriptor and sets it to expire
+    after the given number of seconds. It sets the coroutine state to wait
+    on the timer file descriptor and returns the line number where the
+    coroutine was suspended. */
 int
 carrow_sleep(struct carrow_generic_coro *self, unsigned int seconds,
         int line);
 
 
+/* A function that triggers the coroutine associated with the given file
+   descriptor with the provided event mask. */
 int
 carrow_trigger(int fd, int events);
 


### PR DESCRIPTION
In order to grasp a solid understanding of how the carrow is really working, I tried to add documentation to the `carrow.h` file.

This pull request is created for two main purposes:

1. Get to know the Carrow framework.
2. Add documentation to carrow.h file which is the main implementation file for the Carrow framework. 